### PR TITLE
Add verify.walletconnect.org to CSP frame-src

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -119,7 +119,7 @@ const contentSecurityPolicy = {
     'https://unpkg.com/@lottiefiles/dotlottie-web@0.31.1/dist/dotlottie-player.wasm', // lottie player
     `https://${process.env.NEXT_PUBLIC_PINATA_GATEWAY_URL}`,
   ],
-  'frame-src': ['https://p.datadoghq.com'],
+  'frame-src': ['https://p.datadoghq.com', 'https://verify.walletconnect.org'],
   'frame-ancestors': ["'self'", baseXYZDomains],
   'form-action': ["'self'", baseXYZDomains],
   'img-src': [


### PR DESCRIPTION
The Content-Security-Policy header specified by base.org breaks both WalletConnect and Rabby (which apparently uses WalletConnect.) As a result, the BitBox02 hardware wallet is currently unusable with base.org.

I see blocked requests to both verify.walletconnect.com and verify.walletconnect.org to the same URL path; [apps/base-docs/server.js][0] only uses the latter, so I’m assuming only one of them is needed and updated this to match.

[0]: https://github.com/base-org/web/blob/9beb94e4201224dea6234d2a061c9855f5133fd1/apps/base-docs/server.js#L436